### PR TITLE
Add pair/unpair ESPHome actions & make API component use optional

### DIFF
--- a/components/lampsmart_pro_light/lampsmart_pro_light.cpp
+++ b/components/lampsmart_pro_light/lampsmart_pro_light.cpp
@@ -87,8 +87,10 @@ uint16_t v2_crc16_ccitt(uint8_t *src, uint8_t size, uint16_t crc16_result) {
 }
 
 void LampSmartProLight::setup() {
+#ifdef USE_API
   register_service(&LampSmartProLight::on_pair, light_state_ ? "pair_" + light_state_->get_object_id() : "pair");
   register_service(&LampSmartProLight::on_unpair, light_state_ ? "unpair_" + light_state_->get_object_id() : "unpair");
+#endif
 }
 
 light::LightTraits LampSmartProLight::get_traits() {

--- a/components/lampsmart_pro_light/light.py
+++ b/components/lampsmart_pro_light/light.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import light, output
+from esphome import automation
 from esphome.const import (
     CONF_DURATION,
     CONF_CONSTANT_BRIGHTNESS,
@@ -9,6 +10,7 @@ from esphome.const import (
     CONF_WARM_WHITE_COLOR_TEMPERATURE,
     CONF_REVERSED,
     CONF_MIN_BRIGHTNESS, # New in 2023.5
+    CONF_ID,
 )
 
 AUTO_LOAD = ["esp32_ble"]
@@ -16,7 +18,25 @@ DEPENDENCIES = ["esp32"]
 
 lampsmartpro_ns = cg.esphome_ns.namespace('lampsmartpro')
 LampSmartProLight = lampsmartpro_ns.class_('LampSmartProLight', cg.Component, light.LightOutput)
+PairAction = lampsmartpro_ns.class_("PairAction", automation.Action)
+UnpairAction = lampsmartpro_ns.class_("UnpairAction", automation.Action)
 
+
+ACTION_ON_PAIR_SCHEMA = cv.All(
+    automation.maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(light.LightState),
+        }
+    )
+)
+
+ACTION_ON_UNPAIR_SCHEMA = cv.All(
+    automation.maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(light.LightState),
+        }
+    )
+)
 
 CONFIG_SCHEMA = cv.All(
     light.RGB_LIGHT_SCHEMA.extend(
@@ -56,3 +76,14 @@ async def to_code(config):
     cg.add(var.set_reversed(config[CONF_REVERSED]))
     cg.add(var.set_min_brightness(config[CONF_MIN_BRIGHTNESS]))
     cg.add(var.set_tx_duration(config[CONF_DURATION]))
+
+
+@automation.register_action(
+    "lampsmartpro.pair", PairAction, ACTION_ON_PAIR_SCHEMA
+)
+@automation.register_action(
+    "lampsmartpro.unpair", UnpairAction, ACTION_ON_UNPAIR_SCHEMA
+)
+async def lampsmartpro_pair_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, parent)


### PR DESCRIPTION
This pull request wraps the component's `on_pair()` and `on_unpair()` calls with corresponding ESPHome actions `pair` and `unpair`.

Additionally, the component can now be used even when Home Assistant `api` component is not configured.

Both changes allow the component to be used via MQTT only - e.g. a button can be created to start the (un)pairing process. Example:

```
light:
  - platform: lampsmart_pro_light
    id: lights
    name: Living room lights
    duration: 1000
    default_transition_length: 0s
    retain: false

button:
  - platform: template
    name: "Pair"
    on_press:
      - lampsmartpro.pair: lights

  - platform: template
    name: "Unpair"
    on_press:
      - lampsmartpro.unpair: lights
```
