### PR TITLE
variable not instantiated

### DIFF
--- a/components/ble_adv_controller/ble_adv_handler.cpp
+++ b/components/ble_adv_controller/ble_adv_handler.cpp
@@ -44,7 +44,7 @@ void BleAdvParam::from_hex_string(std::string & raw) {
   // convert to integers
   uint8_t raw_int[MAX_PACKET_LEN]{0};
   uint8_t len = std::min(MAX_PACKET_LEN, raw.size()/2);
-  for (uint8_t i; i < len; ++i) {
+  for (uint8_t i=0; i < len; ++i) {
     raw_int[i] = stoi(raw.substr(2*i, 2), 0, 16);
   }
   this->from_raw(raw_int, len);


### PR DESCRIPTION
Had an error when I used the component on a NSPanel unit (flashed with https://github.com/Blackymas/NSPanel_HA_Blueprint) This fixes it.
Should be no problem merging as it only instantiates a local variable.

Sorry for the brevity, I'm on mobile.
No need for steps to reproduce the error or logs/configs as it's pretty obvious.
Tested on NSPanel and it compiles/links properly and the component works as it should.