### PR TITLE
Fix access to `scan_result_` fields (Requires 2025.6.1)

### DIFF
--- a/components/ble_adv_controller/ble_adv_handler.cpp
+++ b/components/ble_adv_controller/ble_adv_handler.cpp
@@ -280,7 +280,7 @@ void BleAdvHandler::on_raw_decode(std::string raw) {
 class HackESPBTDevice: public esp32_ble_tracker::ESPBTDevice {
 public:
   void get_raw_packet(BleAdvParam & param) const {
-    param.from_raw(this->scan_result_.ble_adv, this->scan_result_.adv_data_len);
+    param.from_raw(this->scan_result_->ble_adv, this->scan_result_->adv_data_len);
   }
 };
 


### PR DESCRIPTION
`scan_result_` is now a pointer, so its fields should be accessed with `->`, not `.` This is a breaking change, and will work starting with ESPHome 2025.6.1